### PR TITLE
Add medication card with edit and delete medication

### DIFF
--- a/app/navigation/RootNavigator.tsx
+++ b/app/navigation/RootNavigator.tsx
@@ -9,11 +9,12 @@ import { useAuth } from '../contexts/AuthContext';
 import HomeScreen from '../screens/HomeScreen';
 import LoginScreen from '../screens/LoginScreen';
 import PrescriptionsScreen from '../screens/PrescriptionsScreen';
-import MedicationSearchScreen from '../screens/prescriptions/MedicationSearchScreen';
+import ProfileScreen from '../screens/ProfileScreen';
+import MedicationConfirmScreen from '../screens/prescriptions/MedicationConfirmScreen';
 import MedicationDetailScreen from '../screens/prescriptions/MedicationDetailScreen';
 import MedicationScheduleScreen from '../screens/prescriptions/MedicationScheduleScreen';
-import MedicationConfirmScreen from '../screens/prescriptions/MedicationConfirmScreen';
-import ProfileScreen from '../screens/ProfileScreen';
+import MedicationSearchScreen from '../screens/prescriptions/MedicationSearchScreen';
+import MedicationViewScreen from '../screens/prescriptions/MedicationViewScreen';
 import EditProfileScreen from '../screens/profile/EditProfileScreen';
 
 // Import types
@@ -48,6 +49,8 @@ function HomeNavigator() {
   return (
     <HomeStack.Navigator screenOptions={{ headerShown: false }}>
       <HomeStack.Screen name="HomeMain" component={HomeScreen} />
+      <HomeStack.Screen name="MedicationView" component={MedicationViewScreen} />
+      <HomeStack.Screen name="MedicationSchedule" component={MedicationScheduleScreen} />
     </HomeStack.Navigator>
   );
 }
@@ -61,6 +64,7 @@ function PrescriptionsNavigator() {
       <PrescriptionsStack.Screen name="MedicationDetail" component={MedicationDetailScreen} />
       <PrescriptionsStack.Screen name="MedicationSchedule" component={MedicationScheduleScreen} />
       <PrescriptionsStack.Screen name="MedicationConfirm" component={MedicationConfirmScreen} />
+      <PrescriptionsStack.Screen name="MedicationView" component={MedicationViewScreen} />
     </PrescriptionsStack.Navigator>
   );
 }

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -1,9 +1,17 @@
 import { Ionicons } from "@expo/vector-icons";
+import { useNavigation } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { useState } from "react";
 import { Modal, ScrollView, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { Button } from "../components/button";
 import { Card, CardContent } from "../components/card";
 import { useAuth } from "../contexts/AuthContext";
+import type { HomeStackParamList } from "../types/navigation";
+
+type HomeScreenNavigationProp = NativeStackNavigationProp<
+  HomeStackParamList,
+  "HomeMain"
+>;
 
 // Placeholder data -  replace with real data later
 const PLACEHOLDER_MEDICATIONS: Medication[] = [
@@ -26,6 +34,7 @@ interface Medication {
 
 export default function HomeScreen() {
   const { user } = useAuth();
+  const navigation = useNavigation<HomeScreenNavigationProp>();
   const [medications, setMedications] = useState<Medication[]>(PLACEHOLDER_MEDICATIONS);
   const [modalVisible, setModalVisible] = useState(false);
   const [selectedMedication, setSelectedMedication] = useState<Medication | null>(null);
@@ -80,6 +89,29 @@ export default function HomeScreen() {
     setSelectedStatus(null);
   };
 
+  // Handle view details - navigate to medication view
+  const handleViewDetails = () => {
+    // For now, using placeholder data structure
+    // In a real app, you'd fetch the full medication data
+    const mockMedication = {
+      id: "1",
+      medicationName: nextMed?.name.toLowerCase() || "medication",
+      fdaData: {
+        brandName: nextMed?.name || "Medication",
+      },
+      schedule: {
+        times: [nextMed?.time || "09:00"],
+        frequency: "Daily",
+      },
+      duration: {
+        type: "permanent",
+      },
+      dosage: "As prescribed",
+    };
+    
+    navigation.navigate("MedicationView", { medication: mockMedication });
+  };
+
   const nextMed = getNextMedication();
   const progress = getTodaysProgress();
 
@@ -103,7 +135,7 @@ export default function HomeScreen() {
               <Text style={styles.medicationTime}>at {nextMed.time}</Text>
               <Button 
                 style={styles.detailsButton}
-                disabled={true}
+                onPress={handleViewDetails}
               >
                 View details
               </Button>

--- a/app/screens/PrescriptionsScreen.tsx
+++ b/app/screens/PrescriptionsScreen.tsx
@@ -3,22 +3,22 @@ import { useFocusEffect, useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import React, { useCallback, useEffect, useState } from "react";
 import {
-  ActivityIndicator,
-  ScrollView,
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-  View,
+    ActivityIndicator,
+    ScrollView,
+    StyleSheet,
+    Text,
+    TouchableOpacity,
+    View,
 } from "react-native";
 import { Button } from "../components/button";
 import {
-  Card,
-  CardAction,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
+    Card,
+    CardAction,
+    CardContent,
+    CardDescription,
+    CardFooter,
+    CardHeader,
+    CardTitle,
 } from "../components/card";
 import { useAuth } from "../contexts/AuthContext";
 import { medicationService } from "../services/medicationService";
@@ -113,7 +113,7 @@ export default function PrescriptionsScreen() {
   };
 
   const handleMedicationPress = (medication: Medication) => {
-    // TODO: Navigate to medication detail screen
+    navigation.navigate("MedicationView", { medication });
   };
 
   const formatSchedule = (medication: Medication) => {

--- a/app/screens/prescriptions/MedicationViewScreen.tsx
+++ b/app/screens/prescriptions/MedicationViewScreen.tsx
@@ -1,0 +1,588 @@
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+import type { RouteProp } from "@react-navigation/native";
+import { useNavigation, useRoute } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import React, { useState } from "react";
+import {
+    ScrollView,
+    StyleSheet,
+    Text,
+    TouchableOpacity,
+    View
+} from "react-native";
+import { Button } from "../../components/button";
+import ConfirmationModal from "../../components/ConfirmationModal";
+import { useAuth } from "../../contexts/AuthContext";
+import { medicationService } from "../../services/medicationService";
+import type { PrescriptionsStackParamList } from "../../types/navigation";
+
+type MedicationViewNavigationProp = NativeStackNavigationProp<
+  PrescriptionsStackParamList,
+  "MedicationView"
+>;
+
+type MedicationViewRouteProp = RouteProp<
+  PrescriptionsStackParamList,
+  "MedicationView"
+>;
+
+const BackIcon = () => (
+  <MaterialCommunityIcons name="chevron-left" size={28} color="#3B82F6" />
+);
+
+const EditIcon = () => (
+  <MaterialCommunityIcons name="pencil" size={20} color="#FFFFFF" />
+);
+
+const DeleteIcon = () => (
+  <MaterialCommunityIcons name="delete" size={20} color="#FFFFFF" />
+);
+
+export default function MedicationViewScreen() {
+  const navigation = useNavigation<MedicationViewNavigationProp>();
+  const route = useRoute<MedicationViewRouteProp>();
+  const { user } = useAuth();
+  const { medication } = route.params;
+
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const displayName =
+    medication.fdaData?.brandName ||
+    medication.medicationName.charAt(0).toUpperCase() +
+      medication.medicationName.slice(1);
+
+  const handleBack = () => {
+    navigation.goBack();
+  };
+
+  const handleEdit = () => {
+    navigation.navigate("MedicationSchedule", {
+      medicationName: medication.medicationName,
+      brandName: displayName,
+      genericName: medication.fdaData?.genericName,
+      fdaData: medication.fdaData,
+      existingMedication: medication,
+    });
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!medication.id) return;
+
+    setIsDeleting(true);
+    try {
+      const result = await medicationService.deleteMedication(medication.id);
+
+      if (result.success) {
+        setShowDeleteModal(false);
+        navigation.goBack();
+      } else {
+        console.error("Failed to delete medication:", result.error);
+        alert("Failed to delete medication. Please try again.");
+      }
+    } catch (error) {
+      console.error("Error deleting medication:", error);
+      alert("An error occurred. Please try again.");
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  // Format schedule information
+  const getScheduleInfo = () => {
+    const { schedule } = medication;
+    const times = schedule.times || [];
+
+    if (times.length === 0) return null;
+
+    const frequency = schedule.frequency || "";
+    const startTime = times[0];
+    const endTime = times[times.length - 1];
+
+    return {
+      frequency,
+      times,
+      startTime,
+      endTime,
+      hoursBetweenDoses: schedule.hoursBetweenDoses,
+    };
+  };
+
+  // Format duration information
+  const formatDuration = () => {
+    if (medication.duration) {
+      if (medication.duration.type === "permanent") {
+        return "Permanent";
+      }
+      if (medication.duration.type === "limited" && medication.duration.days) {
+        return `${medication.duration.days}-day course`;
+      }
+    }
+    return "Not specified";
+  };
+
+  // Get completion status
+  const getCompletionStatus = () => {
+    if (
+      medication.duration &&
+      medication.duration.type === "limited" &&
+      medication.duration.days
+    ) {
+      const completed = medication.streak || 0;
+      const total = medication.duration.days;
+      return { completed, total };
+    }
+    return null;
+  };
+
+  // Format FDA information
+  const getInformation = () => {
+    const fdaData = medication.fdaData;
+    if (!fdaData) return null;
+
+    // Clean and format text - remove extra spaces and handle arrays
+    const cleanText = (text: string | string[] | undefined) => {
+      if (!text) return null;
+      if (Array.isArray(text)) {
+        const joined = text.join(" ").trim();
+        return joined || null;
+      }
+      return text.trim() || null;
+    };
+
+    return {
+      purpose: cleanText(fdaData.purpose) || cleanText(fdaData.indicationsAndUsage),
+      activeIngredient: cleanText(fdaData.activeIngredient),
+      sideEffects: cleanText(fdaData.adverse_reactions) || cleanText(fdaData.sideEffects),
+      warnings: cleanText(fdaData.warnings),
+      doNotUse: cleanText(fdaData.doNotUse),
+      askDoctor: cleanText(fdaData.askDoctor),
+      stopUse: cleanText(fdaData.stopUse),
+      dosageAndAdministration: cleanText(fdaData.dosageAndAdministration),
+    };
+  };
+
+  const completionStatus = getCompletionStatus();
+  const information = getInformation();
+  const scheduleInfo = getScheduleInfo();
+  const isPermanent = medication.duration?.type === "permanent";
+
+  return (
+    <View style={styles.container}>
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Header with Back Button */}
+        <TouchableOpacity onPress={handleBack} style={styles.backButton}>
+          <BackIcon />
+          <Text style={styles.backText}>Back</Text>
+        </TouchableOpacity>
+
+        {/* Medication Name */}
+        <Text style={styles.title}>{displayName}</Text>
+
+        {/* Schedule Card */}
+        {scheduleInfo ? (
+          <View style={styles.card}>
+            <View style={styles.cardHeader}>
+              <MaterialCommunityIcons
+                name="clock-outline"
+                size={24}
+                color="#3B82F6"
+              />
+              <Text style={styles.cardTitle}>Schedule</Text>
+            </View>
+            
+            {/* Frequency */}
+            {scheduleInfo.frequency && (
+              <View style={styles.scheduleRow}>
+                <Text style={styles.scheduleLabel}>Frequency:</Text>
+                <Text style={styles.scheduleValue}>{scheduleInfo.frequency}</Text>
+              </View>
+            )}
+
+            {/* Start and End Time */}
+            {scheduleInfo.startTime && scheduleInfo.endTime && (
+              <View style={styles.scheduleRow}>
+                <Text style={styles.scheduleLabel}>
+                  {scheduleInfo.times.length === 1 ? "Time:" : "Time window:"}
+                </Text>
+                <Text style={styles.scheduleValue}>
+                  {scheduleInfo.times.length === 1 
+                    ? scheduleInfo.startTime 
+                    : `${scheduleInfo.startTime} - ${scheduleInfo.endTime}`
+                  }
+                </Text>
+              </View>
+            )}
+
+            {/* Medication Times */}
+            {scheduleInfo.times.length > 0 && (
+              <View style={styles.timesSection}>
+                <Text style={styles.scheduleLabel}>Times:</Text>
+                <View style={styles.timesGrid}>
+                  {scheduleInfo.times.map((time: string, index: number) => (
+                    <View key={index} style={styles.timeChip}>
+                      <Text style={styles.timeChipText}>{time}</Text>
+                    </View>
+                  ))}
+                </View>
+              </View>
+            )}
+          </View>
+        ) : (
+          <View style={styles.card}>
+            <View style={styles.cardHeader}>
+              <MaterialCommunityIcons
+                name="clock-outline"
+                size={24}
+                color="#3B82F6"
+              />
+              <Text style={styles.cardTitle}>Schedule</Text>
+            </View>
+            <Text style={styles.cardContent}>No schedule set</Text>
+          </View>
+        )}
+
+        {/* Duration Card */}
+        <View style={styles.card}>
+          <View style={styles.cardHeader}>
+            <MaterialCommunityIcons
+              name="calendar"
+              size={24}
+              color="#3B82F6"
+            />
+            <Text style={styles.cardTitle}>Duration</Text>
+          </View>
+          <Text style={styles.cardContent}>{formatDuration()}</Text>
+
+          {completionStatus && (
+            <View style={styles.progressBadge}>
+              <MaterialCommunityIcons
+                name="calendar-check"
+                size={18}
+                color="#3B82F6"
+              />
+              <Text style={styles.progressText}>
+                {completionStatus.completed}/{completionStatus.total} days
+                completed
+              </Text>
+            </View>
+          )}
+        </View>
+
+        {/* Refill Reminder Card */}
+        {medication.refillReminder && isPermanent && (
+          <View style={styles.card}>
+            <View style={styles.cardHeader}>
+              <MaterialCommunityIcons
+                name="bell-outline"
+                size={24}
+                color="#3B82F6"
+              />
+              <Text style={styles.cardTitle}>Refill Reminder</Text>
+            </View>
+            <Text style={styles.cardContent}>
+              Every {medication.refillReminder} days
+            </Text>
+          </View>
+        )}
+
+        {/* Information Card */}
+        {information && (
+          <View style={[styles.card, styles.infoCard]}>
+            <Text style={styles.infoTitle}>Information</Text>
+
+            {/* Purpose */}
+            {information.purpose && (
+              <>
+                <Text style={styles.infoSubtitle}>Purpose</Text>
+                <Text style={styles.infoText}>{information.purpose}</Text>
+              </>
+            )}
+
+            {/* Active Ingredient */}
+            {information.activeIngredient && (
+              <>
+                <Text style={styles.infoSubtitle}>Active Ingredient</Text>
+                <Text style={styles.infoText}>{information.activeIngredient}</Text>
+              </>
+            )}
+
+            {/* Common Side Effects */}
+            {information.sideEffects && (
+              <>
+                <Text style={styles.infoSubtitle}>Common side effects:</Text>
+                <Text style={styles.infoText}>{information.sideEffects}</Text>
+              </>
+            )}
+
+            {/* Do Not Use */}
+            {information.doNotUse && (
+              <>
+                <Text style={styles.infoSubtitle}>Do not use if:</Text>
+                <Text style={styles.infoText}>{information.doNotUse}</Text>
+              </>
+            )}
+
+            {/* Ask Doctor */}
+            {information.askDoctor && (
+              <>
+                <Text style={styles.infoSubtitle}>Ask a doctor before use if:</Text>
+                <Text style={styles.infoText}>{information.askDoctor}</Text>
+              </>
+            )}
+
+            {/* Stop Use */}
+            {information.stopUse && (
+              <>
+                <Text style={styles.infoSubtitle}>Stop use and ask a doctor if:</Text>
+                <Text style={styles.infoText}>{information.stopUse}</Text>
+              </>
+            )}
+
+            {/* Dosage and Administration */}
+            {information.dosageAndAdministration && (
+              <>
+                <Text style={styles.infoSubtitle}>Dosage and Administration</Text>
+                <Text style={styles.infoText}>{information.dosageAndAdministration}</Text>
+              </>
+            )}
+
+            {/* Warning Box - at the bottom */}
+            {information.warnings && (
+              <View style={styles.warningBox}>
+                <MaterialCommunityIcons
+                  name="alert-circle"
+                  size={20}
+                  color="#F59E0B"
+                />
+                <View style={styles.warningContent}>
+                  <Text style={styles.warningTitle}>Warning</Text>
+                  <Text style={styles.warningText}>{information.warnings}</Text>
+                </View>
+              </View>
+            )}
+
+            {/* No information available message */}
+            {!information.purpose && 
+             !information.activeIngredient && 
+             !information.sideEffects && 
+             !information.warnings && 
+             !information.doNotUse && 
+             !information.askDoctor && 
+             !information.stopUse && 
+             !information.dosageAndAdministration && (
+              <Text style={styles.noInfoText}>
+                No additional information available for this medication.
+              </Text>
+            )}
+          </View>
+        )}
+
+        {/* Edit Button */}
+        <Button
+          onPress={handleEdit}
+          style={styles.editButton}
+          icon={<EditIcon />}
+          iconPosition="left"
+        >
+          Edit Medication
+        </Button>
+
+        {/* Delete Button */}
+        <Button
+          onPress={() => setShowDeleteModal(true)}
+          style={styles.deleteButton}
+          icon={<DeleteIcon />}
+          iconPosition="left"
+        >
+          Delete Medication
+        </Button>
+      </ScrollView>
+
+      {/* Delete Confirmation Modal */}
+      <ConfirmationModal
+        visible={showDeleteModal}
+        title="Delete Medication?"
+        message={`Are you sure you want to delete ${displayName}? This action cannot be undone.`}
+        confirmText={isDeleting ? "Deleting..." : "Delete"}
+        cancelText="Cancel"
+        onConfirm={handleDeleteConfirm}
+        onCancel={() => setShowDeleteModal(false)}
+        destructive={true}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#E0F2FE",
+  },
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    padding: 20,
+    paddingTop: 60,
+    paddingBottom: 40,
+  },
+  backButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 16,
+  },
+  backText: {
+    fontSize: 17,
+    color: "#3B82F6",
+    marginLeft: 4,
+    fontWeight: "500",
+  },
+  title: {
+    fontSize: 32,
+    fontWeight: "700",
+    color: "#1E40AF",
+    marginBottom: 24,
+  },
+  card: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: 16,
+    padding: 20,
+    marginBottom: 16,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.05,
+    shadowRadius: 3,
+    elevation: 2,
+  },
+  cardHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 12,
+    gap: 8,
+  },
+  cardTitle: {
+    fontSize: 18,
+    fontWeight: "600",
+    color: "#1F2937",
+  },
+  cardContent: {
+    fontSize: 16,
+    color: "#4B5563",
+    lineHeight: 24,
+  },
+  scheduleRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 8,
+  },
+  scheduleLabel: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: "#6B7280",
+  },
+  scheduleValue: {
+    fontSize: 15,
+    color: "#1F2937",
+    fontWeight: "500",
+  },
+  timesSection: {
+    marginTop: 12,
+  },
+  timesGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+    marginTop: 8,
+  },
+  timeChip: {
+    backgroundColor: "#EFF6FF",
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "#DBEAFE",
+  },
+  timeChipText: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: "#3B82F6",
+  },
+  progressBadge: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    backgroundColor: "#EFF6FF",
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+    marginTop: 12,
+    alignSelf: "flex-start",
+  },
+  progressText: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: "#3B82F6",
+  },
+  infoCard: {
+    paddingVertical: 24,
+  },
+  infoTitle: {
+    fontSize: 18,
+    fontWeight: "600",
+    color: "#1F2937",
+    marginBottom: 16,
+  },
+  infoSubtitle: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: "#1F2937",
+    marginBottom: 8,
+    marginTop: 12,
+  },
+  infoText: {
+    fontSize: 15,
+    color: "#4B5563",
+    lineHeight: 22,
+  },
+  noInfoText: {
+    fontSize: 15,
+    color: "#9CA3AF",
+    lineHeight: 22,
+    fontStyle: "italic",
+  },
+  warningBox: {
+    flexDirection: "row",
+    backgroundColor: "#FEF3C7",
+    borderRadius: 12,
+    padding: 16,
+    gap: 12,
+    marginTop: 8,
+  },
+  warningContent: {
+    flex: 1,
+  },
+  warningTitle: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: "#92400E",
+    marginBottom: 4,
+  },
+  warningText: {
+    fontSize: 14,
+    color: "#78350F",
+    lineHeight: 20,
+  },
+  editButton: {
+    marginTop: 8,
+    marginBottom: 12,
+  },
+  deleteButton: {
+    backgroundColor: "#EF4444",
+  },
+});

--- a/app/types/navigation.ts
+++ b/app/types/navigation.ts
@@ -17,6 +17,16 @@ export type MainTabParamList = {
 // Home Stack - nested screens from Home tab
 export type HomeStackParamList = {
   HomeMain: undefined;
+  MedicationView: {
+    medication: any;
+  };
+  MedicationSchedule: {
+    medicationName: string;
+    brandName: string;
+    genericName?: string;
+    fdaData?: any;
+    existingMedication?: any;
+  };
   // Add more home-related screens here
   // Example: MedicationDetails: { medicationId: string };
 };
@@ -59,6 +69,9 @@ export type PrescriptionsStackParamList = {
       refillReminder?: number;
     };
     existingMedicationId?: string;
+  };
+  MedicationView: {
+    medication: any;
   };
 };
 


### PR DESCRIPTION
This pull request introduces the new `MedicationViewScreen` and integrates it into both the Home and Prescriptions navigation stacks, enabling users to view medication details from multiple entry points. Additionally, it enhances the medication schedule editing workflow, allowing direct updates to medication schedules and improving user feedback during updates.

**Navigation and Screen Integration:**

* Added `MedicationViewScreen` to both Home and Prescriptions navigation stacks, updating imports and navigator definitions in `RootNavigator.tsx` to allow navigation to the new screen from relevant places.
* Updated navigation type definitions in `navigation.ts` to include `MedicationView` routes and their parameters for both Home and Prescriptions stacks. 

**Home Screen Enhancements:**

* Implemented navigation from the Home screen's "View details" button to the new `MedicationViewScreen`, passing mock medication data for now. 

**Prescriptions Screen Improvements:**

* Updated the medication list in the Prescriptions screen so that tapping a medication navigates to `MedicationViewScreen` with the selected medication's data.

**Medication Schedule Editing Workflow:**

* Enhanced `MedicationScheduleScreen` to support direct medication updates in edit mode:
  - Utilizes dot notation for Firestore updates and `deleteField` to properly handle nested fields and field removals.
  - Adds loading state and user feedback during updates.
  - Navigates back to the main prescriptions screen upon successful update. 